### PR TITLE
Endpoint para obtener perfil

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,7 +1,8 @@
-import {Body, Controller, Post} from '@nestjs/common';
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
-import {ApiTags} from "@nestjs/swagger";
-import {LoginDto} from "./dto/login.dto";
+import { LoginDto } from './dto/login.dto';
+import { JwtAuthGuard } from './jwt-auth.guard';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -11,5 +12,11 @@ export class AuthController {
   @Post('login')
   logi(@Body() { email, password }: LoginDto) {
     return this.authService.login(email, password);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('me')
+  getProfile(@Req() req) {
+    return req.user;
   }
 }


### PR DESCRIPTION
Esta PR agrega un endpoint para poder obtener información del usuario haciendo uso del jwt token enviado en el header de la request.

Desde el frontend se puede consumir informacion relacionada al usuario, en el ejemplo se puede ver el email del usuario con la sesion iniciada.
![localhost_4001_home](https://github.com/user-attachments/assets/11046660-ad8b-4ae7-a30f-acf5aa99a69b)
